### PR TITLE
feat: Add Mistral.Models module and proxy function to Mistral client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Add `Mistral.Models` module for working with Mistral's models API
+  - `list/1` - List all available models
+  - `get/2` - Retrieve information about a specific model
+
 ## [0.2.0] - 2025-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Mistral is an open-source Elixir client for the [Mistral AI API](https://docs.mi
 - 🔢 Embeddings
 - 🌊 Streaming Support
 - 🛡️ Error Handling
+- 📋 Models API
 
 ## Installation
 

--- a/lib/mistral.ex
+++ b/lib/mistral.ex
@@ -430,24 +430,45 @@ defmodule Mistral do
     end
   end
 
+  @doc """
+  Returns a `Mistral.Models` context struct for accessing model-specific functions.
+
+  This function creates a proxy module for model-related API calls, allowing you
+  to access functions like `list/1` or `get/2` directly through the client without
+  cluttering the main module.
+
+  ## Examples
+
+      iex> client = Mistral.init("your_api_key")
+      iex> models = Mistral.models(client)
+      %Mistral.Models{client: client}
+
+      # List all available models using the models context:
+      iex> models.list()
+      {:ok, %{"data" => [%{"id" => "mistral-small-latest", ...}], ...}}
+  """
+  def models(%__MODULE__{} = client) do
+    %Mistral.Models{client: client}
+  end
+
   @spec req(client(), atom(), Req.url(), keyword()) :: req_response()
-  defp req(%__MODULE__{req: req}, method, url, opts) do
+  def req(%__MODULE__{req: req}, method, url, opts) do
     opts = Keyword.merge(opts, method: method, url: url)
     Req.request(req, opts)
   end
 
   @spec res(req_response()) :: response()
-  defp res({:ok, %Task{} = task}), do: {:ok, task}
-  defp res({:ok, stream}) when is_function(stream), do: {:ok, stream}
+  def res({:ok, %Task{} = task}), do: {:ok, task}
+  def res({:ok, stream}) when is_function(stream), do: {:ok, stream}
 
-  defp res({:ok, %Req.Response{status: status, body: ""}}) when status in 200..299,
+  def res({:ok, %Req.Response{status: status, body: ""}}) when status in 200..299,
     do: {:ok, %{}}
 
-  defp res({:ok, %Req.Response{status: status, body: body}}) when status in 200..299,
+  def res({:ok, %Req.Response{status: status, body: body}}) when status in 200..299,
     do: {:ok, body}
 
-  defp res({:ok, resp}),
+  def res({:ok, resp}),
     do: {:error, APIError.exception(resp)}
 
-  defp res({:error, error}), do: {:error, error}
+  def res({:error, error}), do: {:error, error}
 end

--- a/lib/mistral/models.ex
+++ b/lib/mistral/models.ex
@@ -1,0 +1,82 @@
+defmodule Mistral.Models do
+  @moduledoc """
+  Functions for interacting with the Mistral Models API.
+
+  This module provides functionality to retrieve information about
+  the available models and their capabilities.
+  """
+  use Mistral.Schemas
+
+  defstruct [:client]
+
+  schema(:list_params, [
+    # Currently no parameters are used, but this structure allows for future
+    # expansion if the API adds pagination or filtering
+  ])
+
+  @doc """
+  Lists all available models.
+
+  ## Examples
+
+      iex> Mistral.Models.list(client)
+      {:ok, %{
+        "object" => "list",
+        "data" => [
+          %{
+            "id" => "mistral-small-latest",
+            "object" => "model",
+            "created" => 1711430400,
+            "owned_by" => "mistralai",
+            "capabilities" => %{
+              "completion_chat" => true,
+              "function_calling" => true
+            }
+          }
+        ]
+      }}
+  """
+  @spec list(Mistral.client(), keyword()) :: Mistral.response()
+  def list(%Mistral{} = client, params \\ []) do
+    with {:ok, params} <- NimbleOptions.validate(params, schema(:list_params)) do
+      req(client, :get, "/models", params: params)
+    end
+  end
+
+  @doc """
+  Retrieves information about a specific model by its ID.
+
+  ## Parameters
+
+    - `client`: A `Mistral.client()` struct.
+    - `model_id`: The ID of the model to retrieve (e.g. "mistral-small-latest").
+
+  ## Examples
+
+      iex> Mistral.Models.get(client, "mistral-small-latest")
+      {:ok, %{
+        "id" => "mistral-small-latest",
+        "object" => "model",
+        "created" => 1711430400,
+        "owned_by" => "mistralai",
+        "capabilities" => %{
+          "completion_chat" => true,
+          "function_calling" => true,
+          "vision" => false
+        },
+        "name" => "Mistral Small"
+      }}
+  """
+  @spec get(Mistral.client(), String.t()) :: Mistral.response()
+  def get(%Mistral{} = client, model_id) when is_binary(model_id) do
+    req(client, :get, "/models/#{model_id}")
+  end
+
+  # Helper function to make requests and process responses.
+  @spec req(Mistral.client(), atom(), String.t(), keyword()) :: Mistral.response()
+  defp req(%Mistral{} = client, method, path, opts \\ []) do
+    client
+    |> Mistral.req(method, path, opts)
+    |> Mistral.res()
+  end
+end

--- a/test/mistral/models_test.exs
+++ b/test/mistral/models_test.exs
@@ -20,7 +20,7 @@ defmodule Mistral.ModelsTest do
           },
           "name" => "Mistral Small",
           "description" => "Mistral AI's flagship small model",
-          "max_context_length" => 32768,
+          "max_context_length" => 32_768,
           "aliases" => ["mistral-small"],
           "type" => "base"
         },
@@ -38,7 +38,7 @@ defmodule Mistral.ModelsTest do
           },
           "name" => "Mistral Large",
           "description" => "Mistral AI's flagship large model",
-          "max_context_length" => 32768,
+          "max_context_length" => 32_768,
           "aliases" => ["mistral-large"],
           "type" => "base"
         }
@@ -59,7 +59,7 @@ defmodule Mistral.ModelsTest do
       },
       "name" => "Mistral Small",
       "description" => "Mistral AI's flagship small model",
-      "max_context_length" => 32768,
+      "max_context_length" => 32_768,
       "aliases" => ["mistral-small"],
       "type" => "base"
     }

--- a/test/mistral/models_test.exs
+++ b/test/mistral/models_test.exs
@@ -1,0 +1,112 @@
+defmodule Mistral.ModelsTest do
+  use ExUnit.Case, async: true
+  alias Mistral.Mock
+
+  setup do
+    model_list = %{
+      "object" => "list",
+      "data" => [
+        %{
+          "id" => "mistral-small-latest",
+          "object" => "model",
+          "created" => 1_711_430_400,
+          "owned_by" => "mistralai",
+          "capabilities" => %{
+            "completion_chat" => true,
+            "completion_fim" => false,
+            "function_calling" => true,
+            "fine_tuning" => false,
+            "vision" => false
+          },
+          "name" => "Mistral Small",
+          "description" => "Mistral AI's flagship small model",
+          "max_context_length" => 32768,
+          "aliases" => ["mistral-small"],
+          "type" => "base"
+        },
+        %{
+          "id" => "mistral-large-latest",
+          "object" => "model",
+          "created" => 1_711_430_400,
+          "owned_by" => "mistralai",
+          "capabilities" => %{
+            "completion_chat" => true,
+            "completion_fim" => false,
+            "function_calling" => true,
+            "fine_tuning" => false,
+            "vision" => true
+          },
+          "name" => "Mistral Large",
+          "description" => "Mistral AI's flagship large model",
+          "max_context_length" => 32768,
+          "aliases" => ["mistral-large"],
+          "type" => "base"
+        }
+      ]
+    }
+
+    model = %{
+      "id" => "mistral-small-latest",
+      "object" => "model",
+      "created" => 1_711_430_400,
+      "owned_by" => "mistralai",
+      "capabilities" => %{
+        "completion_chat" => true,
+        "completion_fim" => false,
+        "function_calling" => true,
+        "fine_tuning" => false,
+        "vision" => false
+      },
+      "name" => "Mistral Small",
+      "description" => "Mistral AI's flagship small model",
+      "max_context_length" => 32768,
+      "aliases" => ["mistral-small"],
+      "type" => "base"
+    }
+
+    Mock.add_mock(:list_models, model_list)
+    Mock.add_mock(:get_model, model)
+
+    :ok
+  end
+
+  describe "list/1" do
+    test "lists all available models" do
+      client = Mock.client(&Mock.respond(&1, :list_models))
+      assert {:ok, response} = Mistral.Models.list(client)
+
+      assert response["object"] == "list"
+      assert is_list(response["data"])
+
+      model = Enum.at(response["data"], 0)
+      assert is_map(model)
+      assert is_binary(model["id"])
+      assert is_map(model["capabilities"])
+    end
+
+    test "handles errors" do
+      client = Mock.client(&Mock.respond(&1, 401))
+      assert {:error, error} = Mistral.Models.list(client)
+      assert error.status == 401
+      assert error.type == "unauthorized"
+    end
+  end
+
+  describe "get/2" do
+    test "retrieves a specific model by ID" do
+      client = Mock.client(&Mock.respond(&1, :get_model))
+      assert {:ok, model} = Mistral.Models.get(client, "mistral-small-latest")
+
+      assert model["id"] == "mistral-small-latest"
+      assert model["object"] == "model"
+      assert is_map(model["capabilities"])
+    end
+
+    test "handles model not found" do
+      client = Mock.client(&Mock.respond(&1, 404))
+      assert {:error, error} = Mistral.Models.get(client, "nonexistent-model")
+      assert error.status == 404
+      assert error.type == "not_found"
+    end
+  end
+end


### PR DESCRIPTION
- Introduce the `Mistral.Models` module to encapsulate model-specific API calls, including functions for listing available models and retrieving model details.
- Define a struct in `Mistral.Models` to hold the client context.
- Add a new `models/1` function in the main `Mistral` module that returns a `%Mistral.Models{client: client}` struct, providing a clean namespace for model operations.
- Refactor the request helper functions to allow `Mistral.Models` to delegate API requests via the public functions in the main client.

This refactoring improves code organization and maintainability by separating model-related functionality into its own module.