### PR TITLE
feat: Add get_file and get_file_url endpoints to Mistral clien

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `Mistral.Models` module for working with Mistral's models API
   - `list/1` - List all available models
   - `get/2` - Retrieve information about a specific model
-- `upload_file/3` function for uploading files to the Mistral API with support for OCR, fine-tuning, and batch processing purposes.
+- Support Mistral API file endpoints
+  - `upload_file/3` function for uploading files to the Mistral API with support for OCR, fine-tuning, and batch processing purposes.
+  - `get_file/2` to retrieve file details.
+  - `get_file_url/2` to obtain a signed URL for a file with optional `expiry` parameter validation.
 
 ## [0.2.0] - 2025-03-13
 


### PR DESCRIPTION
This commit introduces two new functions to the Mistral client:

- `get_file/2`: Retrieves detailed information about a specific file using its file ID.
- `get_file_url/2`: Fetches a signed URL for a given file, allowing clients to access the file content. The function validates query options using a dedicated schema (`:get_file_url_opts`) and passes the expiry parameter as a query parameter using `params`.

These additions align the client with the Mistral API specification for file management and improve our library's file handling capabilities.
