### PR TITLE
feat: Add OCR support to Mistral client

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter,.credog}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter,.credo}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `upload_file/3` function for uploading files to the Mistral API with support for OCR, fine-tuning, and batch processing purposes.
   - `get_file/2` to retrieve file details.
   - `get_file_url/2` to obtain a signed URL for a file with optional `expiry` parameter validation.
+- **OCR API Support:**
+  - Introduced `Mistral.ocr/2` to process document and image OCR via `/v1/ocr`.
+  - Added `ocr_opts` validation schema for structured request validation.
 
 ## [0.2.0] - 2025-03-13
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Mistral is an open-source Elixir client for the [Mistral AI API](https://docs.mi
 - 🌊 Streaming Support
 - 🛡️ Error Handling
 - ⬆️ File Uploading
-- 📄 OCR
+- 📄 OCR (Optical Character Recognition)
 - 🤖 Models API
 
 ## Installation
@@ -92,10 +92,10 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## Roadmap
 
-- [ ] OCR (Optical Character Recognition) Support
+- [X] OCR (Optical Character Recognition) Support
 - [ ] Batch Processing Support
 - [ ] Advanced Streaming Improvements
-- [ ] Enhanced Error Handling
+- [X] Enhanced Error Handling
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Mistral is an open-source Elixir client for the [Mistral AI API](https://docs.mi
 
 ## Features
 
-- 🚀 Chat Completions
-- 🧩 Function Calling / Tool Use
+- 💬 Chat Completions
+- 🛠 Function Calling / Tool Use
 - 🔢 Embeddings
 - 🌊 Streaming Support
 - 🛡️ Error Handling
-- 📋 Models API
+- ⬆️ File Uploading
+- 📄 OCR
+- 🤖 Models API
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mistral
 
+[![Hex.pm Version](https://img.shields.io/hexpm/v/mistral)](https://hex.pm/packages/mistral)
+[![Hex.pm Download Total](https://img.shields.io/hexpm/dt/mistral)](https://hex.pm/packages/mistral)
 ![GitHub CI](https://github.com/rodloboz/mistral/actions/workflows/all-checks-pass.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/lib/mistral.ex
+++ b/lib/mistral.ex
@@ -218,7 +218,7 @@ defmodule Mistral do
 
   schema(:document_url_chunk,
     type: [
-      type: :string,
+      type: {:in, ["document_url"]},
       required: true,
       default: "document_url",
       doc: "Type of document, must be 'document_url'."

--- a/lib/mistral.ex
+++ b/lib/mistral.ex
@@ -216,6 +216,76 @@ defmodule Mistral do
     ]
   )
 
+  schema(:document_url_chunk,
+    type: [
+      type: :string,
+      required: true,
+      default: "document_url",
+      doc: "Type of document, must be 'document_url'."
+    ],
+    document_url: [
+      type: :string,
+      required: true,
+      doc: "URL of the document to be processed."
+    ],
+    document_name: [
+      type: {:or, [:string, nil]},
+      doc: "Optional filename of the document."
+    ]
+  )
+
+  schema(:image_url_chunk,
+    type: [
+      type: :string,
+      required: true,
+      default: "image_url",
+      doc: "Type of image, must be 'image_url'."
+    ],
+    image_url: [
+      type: :string,
+      required: true,
+      doc: "URL of the image to be processed."
+    ]
+  )
+
+  schema(:ocr_opts,
+    model: [
+      type: {:or, [:string, nil]},
+      required: true,
+      doc: "Model to use for OCR processing."
+    ],
+    id: [
+      type: :string,
+      doc: "Unique identifier for the OCR request."
+    ],
+    document: [
+      type:
+        {:or,
+         [
+           {:map, nested_schema(:document_url_chunk)},
+           {:map, nested_schema(:image_url_chunk)}
+         ]},
+      required: true,
+      doc: "Document object containing the URL or image URL."
+    ],
+    pages: [
+      type: {:or, [nil, {:list, :integer}]},
+      doc: "List of page indices to process (starting from 0)."
+    ],
+    include_image_base64: [
+      type: {:or, [:boolean, nil]},
+      doc: "Include base64 images in the response."
+    ],
+    image_limit: [
+      type: {:or, [:integer, nil]},
+      doc: "Maximum number of images to extract."
+    ],
+    image_min_size: [
+      type: {:or, [:integer, nil]},
+      doc: "Minimum image dimensions to extract."
+    ]
+  )
+
   @doc """
   Creates a new Mistral API client using the API key set in your application's config.
 
@@ -540,6 +610,31 @@ defmodule Mistral do
 
       {:error, reason} when is_atom(reason) ->
         {:error, %File.Error{reason: reason, action: "read file", path: file_path}}
+    end
+  end
+
+  @doc """
+  Perform OCR on a document or image.
+
+  ## Options
+
+  #{doc(:ocr_opts)}
+
+  ## Examples
+
+      iex> Mistral.ocr(client, model: "mistral-ocr-latest", document: %{type: "document_url", document_url: "https://example.com/sample.pdf"})
+      {:ok, %{"pages" => [...]}}
+
+      iex> Mistral.ocr(client, model: "mistral-ocr-latest", document: %{type: "image_url", image_url: "https://example.com/sample.png"})
+      {:ok, %{"pages" => [...]}}
+
+  """
+  @spec ocr(client(), keyword()) :: response()
+  def ocr(%__MODULE__{} = client, params) when is_list(params) do
+    with {:ok, params} <- NimbleOptions.validate(params, schema(:ocr_opts)) do
+      client
+      |> req(:post, "/ocr", json: Enum.into(params, %{}))
+      |> res()
     end
   end
 

--- a/test/support/mock.ex
+++ b/test/support/mock.ex
@@ -10,7 +10,7 @@ defmodule Mistral.Mock do
     chat_completion: %{
       "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
       "object" => "chat.completion",
-      "created" => 1_702_256_327,
+      "created" => 1702256327,
       "model" => "mistral-small-latest",
       "choices" => [
         %{
@@ -135,13 +135,41 @@ defmodule Mistral.Mock do
       "id" => "file-abc123",
       "object" => "file",
       "bytes" => 12345,
-      "created_at" => 1_741_023_462,
+      "created_at" => 1741023462,
       "filename" => "dummy.pdf",
       "purpose" => "ocr",
       "sample_type" => "ocr_input",
       "source" => "upload",
       "deleted" => false,
       "num_lines" => nil
+    },
+    ocr: %{
+      "model" => "mistral-ocr-latest",
+      "pages" => [
+        %{
+          "index" => 0,
+          "markdown" => "some content",
+          "images" => [
+            %{
+              "id" => "img-123456",
+              "top_left_x" => 0,
+              "top_left_y" => 0,
+              "bottom_right_x" => 0,
+              "bottom_right_y" => 0,
+              "image_base64" => "base64representation"
+            }
+          ],
+          "dimensions" => %{
+            "dpi" => 0,
+            "height" => 0,
+            "width" => 0
+          }
+        }
+      ],
+      "usage_info" => %{
+        "pages_processed" => 0,
+        "doc_size_bytes" => 0
+      }
     }
   }
 
@@ -150,7 +178,7 @@ defmodule Mistral.Mock do
       %{
         "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
         "object" => "chat.completion.chunk",
-        "created" => 1_702_256_327,
+        "created" => 1702256327,
         "model" => "mistral-small-latest",
         "choices" => [
           %{
@@ -163,7 +191,7 @@ defmodule Mistral.Mock do
       %{
         "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
         "object" => "chat.completion.chunk",
-        "created" => 1_702_256_327,
+        "created" => 1702256327,
         "model" => "mistral-small-latest",
         "choices" => [
           %{
@@ -176,7 +204,7 @@ defmodule Mistral.Mock do
       %{
         "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
         "object" => "chat.completion.chunk",
-        "created" => 1_702_256_327,
+        "created" => 1702256327,
         "model" => "mistral-small-latest",
         "choices" => [
           %{
@@ -189,7 +217,7 @@ defmodule Mistral.Mock do
       %{
         "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
         "object" => "chat.completion.chunk",
-        "created" => 1_702_256_327,
+        "created" => 1702256327,
         "model" => "mistral-small-latest",
         "choices" => [
           %{

--- a/test/support/mock.ex
+++ b/test/support/mock.ex
@@ -10,7 +10,7 @@ defmodule Mistral.Mock do
     chat_completion: %{
       "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
       "object" => "chat.completion",
-      "created" => 1702256327,
+      "created" => 1_702_256_327,
       "model" => "mistral-small-latest",
       "choices" => [
         %{
@@ -135,7 +135,7 @@ defmodule Mistral.Mock do
       "id" => "file-abc123",
       "object" => "file",
       "bytes" => 12345,
-      "created_at" => 1741023462,
+      "created_at" => 1_741_023_462,
       "filename" => "dummy.pdf",
       "purpose" => "ocr",
       "sample_type" => "ocr_input",
@@ -178,7 +178,7 @@ defmodule Mistral.Mock do
       %{
         "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
         "object" => "chat.completion.chunk",
-        "created" => 1702256327,
+        "created" => 1_702_256_327,
         "model" => "mistral-small-latest",
         "choices" => [
           %{
@@ -191,7 +191,7 @@ defmodule Mistral.Mock do
       %{
         "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
         "object" => "chat.completion.chunk",
-        "created" => 1702256327,
+        "created" => 1_702_256_327,
         "model" => "mistral-small-latest",
         "choices" => [
           %{
@@ -204,7 +204,7 @@ defmodule Mistral.Mock do
       %{
         "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
         "object" => "chat.completion.chunk",
-        "created" => 1702256327,
+        "created" => 1_702_256_327,
         "model" => "mistral-small-latest",
         "choices" => [
           %{
@@ -217,7 +217,7 @@ defmodule Mistral.Mock do
       %{
         "id" => "cmpl-e5cc70bb28c444948073e77776eb30ef",
         "object" => "chat.completion.chunk",
-        "created" => 1702256327,
+        "created" => 1_702_256_327,
         "model" => "mistral-small-latest",
         "choices" => [
           %{

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,14 +1,1 @@
 ExUnit.start()
-
-if System.get_env("TEST_INTEGRATION") do
-  Application.put_env(:mistral, :api_key, "test_key")
-
-  {:ok, _} =
-    Bandit.start_link(
-      plug: Mistral.MockServer,
-      port: 4001,
-      startup_log: false
-    )
-
-  Application.put_env(:mistral, :api_url, "http://localhost:4001")
-end


### PR DESCRIPTION
## Summary
This PR introduces support for the `/v1/ocr` endpoint in the Mistral API client. It includes:
- Implementation of `Mistral.ocr/2` to perform OCR on document and image URLs.
- Validation schemas for `OCRRequest`, `DocumentURLChunk`, and `ImageURLChunk` using `NimbleOptions`.
- Mock response updates in `Mistral.Mock` to align with the expected OCR API response.
- Test cases covering document OCR, image OCR, and error handling.

## Changes
- Added `ocr_opts` schema for request validation.
- Implemented `Mistral.ocr/2` to send OCR requests and handle responses.
- Updated `Mistral.Mock` with structured OCR response data.
- Updated `MistralTest` to verify correct handling of OCR requests and responses.
