### PR TITLE
feat: Add response format control with JSON schema validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ mistral-*.tar
 
 # macOS specific files
 .DS_Store
+
+# Tools
+.accomplish.toml
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.0] - 2025-07-20
+
+### Added
+
+- **Response Format Control**: Support for JSON mode and structured output with schema validation
+  - `response_format` parameter for `chat/2` with support for `json_object` and `json_schema` types
+  - JSON Schema validation with custom schemas for structured responses
+  - OCR annotation formats: `bbox_annotation_format` and `document_annotation_format` for structured OCR output
+  - Comprehensive validation ensuring `json_schema` is provided when type is `json_schema`
+
 ## [0.3.0] - 2025-03-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -77,6 +77,49 @@ stream
 )
 ```
 
+### Response Format Control
+
+Control the output format for structured responses:
+
+```elixir
+# JSON Object Mode - ensures valid JSON response
+{:ok, response} = Mistral.chat(client,
+  model: "mistral-small-latest",
+  messages: [
+    %{role: "user", content: "Generate a user profile in JSON format"}
+  ],
+  response_format: %{type: "json_object"}
+)
+
+# JSON Schema Mode - validates response against schema
+user_schema = %{
+  type: "object",
+  title: "UserProfile",
+  properties: %{
+    name: %{type: "string", title: "Name"},
+    age: %{type: "integer", title: "Age", minimum: 0},
+    email: %{type: "string", title: "Email"}
+  },
+  required: ["name", "age"],
+  additionalProperties: false
+}
+
+{:ok, response} = Mistral.chat(client,
+  model: "mistral-small-latest",
+  messages: [
+    %{role: "user", content: "Generate a user profile"}
+  ],
+  response_format: %{
+    type: "json_schema",
+    json_schema: %{
+      name: "user_profile",
+      schema: user_schema,
+      strict: true
+    }
+  }
+)
+```
+
 ## Credits & Acknowledgments
 
 This package was heavily inspired by and draws from the excellent implementations of:
@@ -93,9 +136,12 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## Roadmap
 
 - [X] OCR (Optical Character Recognition) Support
-- [ ] Batch Processing Support
-- [ ] Advanced Streaming Improvements
 - [X] Enhanced Error Handling
+- [X] Response Format Control (JSON mode with schema validation)
+- [ ] Classification/Moderation API
+- [ ] Batch Processing Support
+- [ ] Complete File Operations (list, delete, download)
+- [ ] Advanced Streaming Improvements
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Mistral.MixProject do
       app: :mistral,
       name: "Mistral",
       description: "A nifty little library for working with Mistral in Elixir.",
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- Add response_format parameter to chat/2 supporting json_object and json_schema types
- Add bbox_annotation_format and document_annotation_format to OCR
- Add comprehensive validation and testing for structured output
- Update documentation and examples
- Bump version to 0.4.0